### PR TITLE
Fix build prefix appearing in cmake config

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: f23aac6c73594e417af50cb38f1efed88ef1dc14a490f0eff07c7f7b079810a4
 
 build:
-  number: 0
+  number: 1
+  merge_build_host: true
   run_exports:
     - {{ pin_subpackage("mimalloc", max_pin="x.x.x") }}
 
@@ -20,6 +21,8 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
+  run:
+    - sysroot_linux-64 # [linux]
 
 # .
 # ├── include

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cmake
     - ninja
   run:
-    - sysroot_linux-64 # [linux]
+    - sysroot_linux-64  # [linux]
 
 # .
 # ├── include


### PR DESCRIPTION
Fixes https://github.com/conda-forge/mimalloc-feedstock/issues/19

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
